### PR TITLE
FIX: createCustomer and createOrder

### DIFF
--- a/server/src/api/v1/orders/create-order.ts
+++ b/server/src/api/v1/orders/create-order.ts
@@ -7,6 +7,7 @@ import { objectHasRequiredAndNotEmptyKeys } from '../../../functions/check-input
 import { Plan } from '../../../models/plan.model';
 import { Customer } from '../../../models/customer.models';
 import { mapCustomer } from '../../../functions/map-customer.func';
+import { Vars } from '../../../vars';
 
 export async function createOrder(req: Request, res: Response) {
     const incomingData: IncomingOrder = req.body;
@@ -20,7 +21,6 @@ export async function createOrder(req: Request, res: Response) {
         return res.status(400).send(wrapResponse(false, { error: 'Not all required fields have been set' }));
     }
 
-    //Check, if Customer with given params already exists. If not create one.
     let success = true;
 
     // Try to find Plan with given planId
@@ -47,6 +47,8 @@ export async function createOrder(req: Request, res: Response) {
     if (plan.postcode != mappedCustomerData.postcode) {
         return res.status(400).send(wrapResponse(false, { error: 'Postcode of plan and order do not match!' }));
     }
+
+    //Check, if Customer with given params already exists. If not create one.
     let customer: Customer | null = await Customer.findOne(
         {
             where: {
@@ -56,7 +58,8 @@ export async function createOrder(req: Request, res: Response) {
                 streetNumber: mappedCustomerData.streetNumber,
                 postcode: mappedCustomerData.postcode,
                 city: mappedCustomerData.city,
-                is_active: mappedCustomerData.is_active
+                is_active: mappedCustomerData.is_active,
+                userId: Vars.currentUser.id
             }
         })
         .catch((error) => {

--- a/server/src/api/v1/orders/create-order.ts
+++ b/server/src/api/v1/orders/create-order.ts
@@ -59,7 +59,7 @@ export async function createOrder(req: Request, res: Response) {
                 postcode: mappedCustomerData.postcode,
                 city: mappedCustomerData.city,
                 is_active: mappedCustomerData.is_active,
-                userId: Vars.currentUser.id
+                userId: mappedCustomerData.userId
             }
         })
         .catch((error) => {

--- a/server/src/functions/map-customer.func.ts
+++ b/server/src/functions/map-customer.func.ts
@@ -1,8 +1,9 @@
 import { IncomingCustomer, InternalCustomer } from "../interfaces/customers.interface";
+import { Vars } from "../vars";
 
 export function mapCustomer(incomingData: IncomingCustomer): InternalCustomer {
     return {
-        userId: incomingData.userId,
+        userId: Vars.currentUser.id,
         firstName: incomingData.firstName,
         lastName: incomingData.lastName,
         street: incomingData.street,

--- a/server/src/functions/map-customer.func.ts
+++ b/server/src/functions/map-customer.func.ts
@@ -3,7 +3,7 @@ import { Vars } from "../vars";
 
 export function mapCustomer(incomingData: IncomingCustomer): InternalCustomer {
     return {
-        userId: Vars.currentUser.id,
+        userId: Vars.currentUser !== undefined ? Vars.currentUser.id: incomingData.userId,
         firstName: incomingData.firstName,
         lastName: incomingData.lastName,
         street: incomingData.street,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -74,7 +74,7 @@ export default function startServer() {
      */
     app.get('/api/v1/orders', userIsAuthorized, userIsAdmin, (req, res) => getOrders(req, res));
     app.get('/api/v1/orders/:id', userIsAuthorized, (req, res) => getOrder(req, res));
-    app.post('/api/v1/orders', (req, res) => createOrder(req, res));
+    app.post('/api/v1/orders', userIsAuthorized, (req, res) => createOrder(req, res));
     app.post('/orders', (req, res) => createOrder(req, res));
     // following route just to update the order itself. not terminating it (is_active = false, set terminateAt)
     app.put('/api/v1/orders/:id', userIsAuthorized, (req, res) => updateOrder(req, res));


### PR DESCRIPTION
Problem: 
Man konnte einen Customer anlegen für einen anderen User (wenn man dessen userId hatte oder mit einer beliebigen userId)
Gleiches Problem bei der Order. Hier wird nun immer die aktuelle userId übernommen von dem user, der sich eingeloggt hat.
