### PR TITLE
[HOTFIX] deleted customers and orders are not being hidden

### DIFF
--- a/server/src/api/v1/customers/get-customer.ts
+++ b/server/src/api/v1/customers/get-customer.ts
@@ -59,7 +59,7 @@ export async function getCustomers(req: Request, res: Response): Promise<Respons
         raw: true,
     };
     const allowedSearchAndOrderFields = ['firstName', 'lastName', 'postcode'];
-    const allowedFilterFields = ['id', 'userId', 'city', 'lastName', 'postcode'];
+    const allowedFilterFields = ['id', 'userId', 'city', 'lastName', 'postcode', 'is_active'];
     const customResolver = new Map<string, customFilterValueResolver>();
     customResolver.set('is_active', (field: string, req: Request, value: string) => {
         return true;

--- a/server/src/api/v1/orders/get-orders.ts
+++ b/server/src/api/v1/orders/get-orders.ts
@@ -81,7 +81,7 @@ export async function getOrders(req: Request, res: Response): Promise<Response> 
         raw: true,
     };
     const allowedSearchFields = ['referrer'];
-    const allowedFilterFields = ['customerId', 'planId', 'referrer', 'consumption'];
+    const allowedFilterFields = ['customerId', 'planId', 'referrer', 'consumption', 'is_active'];
     const allowedOrderFields = ['customerId', 'planId', 'referrer', 'consumption', 'createdAt', 'terminatedAt'];
     const customResolver = new Map<string, customFilterValueResolver>();
     customResolver.set('is_active', (field: string, req: Request, value: string) => {


### PR DESCRIPTION
Der Query-Builder ignoriert CustomResolver wenn nach diesen nicht vom User aus gefiltert werden darf - das ist ein intended feature, da eigentlich gedacht war, dass damit Inputs von Usern geparst werden, bevor automatisch ein Filter darauf gesetzt wird.

Durch hinzufügen der Felder in allowed Filter Fields wird dies gelöst.

Vorher:
```sql
SELECT "id", "userId", "firstName", "lastName", "street", "streetNumber", "postcode", "city", "is_active", "createdAt", "updatedAt"
FROM "Customers" AS "Customer" 
ORDER BY "Customer"."lastName" ASC 
LIMIT 25;
```

Nachher:
```sql
SELECT "id", "userId", "firstName", "lastName", "street", "streetNumber", "postcode", "city", "is_active", "createdAt", "updatedAt" 
FROM "Customers" AS "Customer" 
WHERE "Customer"."is_active" = true 
ORDER BY "Customer"."lastName" ASC 
LIMIT 25;
```

Nachteil - durch diesen Ansatz kann durch User Input jetzt theoretisch auch gelöschtes gesehen werden, dies muss in Zukunft gelöst werden.